### PR TITLE
Media queries3.0

### DIFF
--- a/src/Cost.tsx
+++ b/src/Cost.tsx
@@ -62,7 +62,11 @@ class Cost extends React.Component<RouteComponentProps, State> {
         <Grid
           height="100vh"
           areas={
-            this.state.width > 950 ? ["a b c", "d e f"] : ["a b", "c d", "e f"]
+            this.state.width > 1075
+              ? ["a b c", "d e f"]
+              : this.state.width < 450
+              ? ["a", "b", "c", "d", "e", "f"]
+              : ["a b", "c d", "e f"]
           }
           columns="3"
           gap="0px"

--- a/src/styles.tsx
+++ b/src/styles.tsx
@@ -3,26 +3,51 @@ import { jsx, css } from "@emotion/core";
 import styled from "@emotion/styled";
 import { Cell } from "styled-css-grid";
 
-const breakpointsW = [575, 950];
-const breakpointsH = [360, 535];
+const breakpointsW = [460, 540, 950, 1075];
+const breakpointsH = [360, 575];
 
 export const mqW = breakpointsW.map(bp => `@media (max-width: ${bp}px)`);
 
 export const mqH = breakpointsH.map(bp => `@media (max-height: ${bp}px)`);
 
-export function getStyles() {
-  const WHITE_COLOR = "#FFFFFF";
-  const BLACK_COLOR = "#000000";
-  const BLUE_COLOR = "#367BBC";
-  const RED_COLOR = "#C14C54";
-  const AXIS_COLOR = "#FFFFFF";
-  const LIGHTGRAY_COLOR = "#4F4F4F";
-  const BLACKDARK_COLOR = "#1A1B1E";
-  const BLACKLIGHT_COLOR = "#292A29";
-  const GREEN_COLOR = "#31D397";
-  const YELLOW_COLOR = "#F0C656";
-  const PURPLE_COLOR = "#b19cd9";
+export const theme = {
+  colour: {
+    WHITE_COLOR: "#FFFFFF",
+    BLACK_COLOR: "#000000",
+    BLUE_COLOR: "#367BBC",
+    RED_COLOR: "#C14C54",
+    AXIS_COLOR: "#FFFFFF",
+    LIGHTGRAY_COLOR: "#4F4F4F",
+    BLACKDARK_COLOR: "#1A1B1E",
+    BLACKLIGHT_COLOR: "#292A29",
+    GREEN_COLOR: "#31D397",
+    YELLOW_COLOR: "#F0C656",
+    PURPLE_COLOR: "#b19cd9"
+  },
+  font: {
+    xs: "8pt",
+    sm: "10pt",
+    base: "12pt",
+    md: "12pt",
+    lg: "14pt",
+    xl: "20pt",
+    xxl: "24pt"
+  },
+  spacing: {
+    two: "2rem",
+    xxs: "0.17rem",
+    xs: "0.33rem",
+    sm: "0.5rem",
+    md: "1.0rem",
+    base: "1.0rem",
+    lg: "1.5rem",
+    xl: "2.5rem",
+    xxl: "5rem",
+    xxxl: "12rem"
+  }
+};
 
+export function getStyles() {
   return {
     labelNumber: {
       fill: "#ffffff",
@@ -32,14 +57,14 @@ export function getStyles() {
 
     // INDEPENDENT AXIS
     axisYears: {
-      grid: { strokeWidth: 1, stroke: LIGHTGRAY_COLOR },
-      axis: { stroke: AXIS_COLOR, strokeWidth: 1 },
+      grid: { strokeWidth: 1, stroke: theme.colour.LIGHTGRAY_COLOR },
+      axis: { stroke: theme.colour.AXIS_COLOR, strokeWidth: 1 },
       ticks: {
-        stroke: AXIS_COLOR,
+        stroke: theme.colour.AXIS_COLOR,
         strokeWidth: 1
       },
       tickLabels: {
-        fill: AXIS_COLOR,
+        fill: theme.colour.AXIS_COLOR,
         fontFamily: "inherit",
         fontSize: "12px"
       }
@@ -47,22 +72,22 @@ export function getStyles() {
 
     // DEPENDANT AXIS
     axisOne: {
-      grid: { strokeWidth: 1, stroke: LIGHTGRAY_COLOR },
-      axis: { stroke: AXIS_COLOR, strokeWidth: 1 },
-      ticks: { stroke: AXIS_COLOR, strokeWidth: 1 },
+      grid: { strokeWidth: 1, stroke: theme.colour.LIGHTGRAY_COLOR },
+      axis: { stroke: theme.colour.AXIS_COLOR, strokeWidth: 1 },
+      ticks: { stroke: theme.colour.AXIS_COLOR, strokeWidth: 1 },
       tickLabels: {
-        fill: AXIS_COLOR,
+        fill: theme.colour.AXIS_COLOR,
         fontFamily: "inherit",
         fontSize: "12px"
       }
     },
 
     axisTwo: {
-      grid: { strokeWidth: 1, stroke: LIGHTGRAY_COLOR },
-      axis: { stroke: AXIS_COLOR, strokeWidth: 1 },
-      ticks: { stroke: AXIS_COLOR, strokeWidth: 1 },
+      grid: { strokeWidth: 1, stroke: theme.colour.LIGHTGRAY_COLOR },
+      axis: { stroke: theme.colour.AXIS_COLOR, strokeWidth: 1 },
+      ticks: { stroke: theme.colour.AXIS_COLOR, strokeWidth: 1 },
       tickLabels: {
-        fill: AXIS_COLOR,
+        fill: theme.colour.AXIS_COLOR,
         fontFamily: "inherit",
         fontSize: "10px"
       }
@@ -70,66 +95,90 @@ export function getStyles() {
 
     // HEROKU WIDGET BAR STYLES
     herokuBar: {
-      data: { fill: GREEN_COLOR },
-      labels: { fill: WHITE_COLOR, fontSize: "12px" }
+      data: { fill: theme.colour.GREEN_COLOR },
+      labels: { fill: theme.colour.WHITE_COLOR, fontSize: "12px" }
     },
 
     // AWS WIDGET BAR STYLES
     AWSBar: {
-      data: { fill: BLUE_COLOR },
-      labels: { fill: WHITE_COLOR, fontSize: "12px" }
+      data: { fill: theme.colour.BLUE_COLOR },
+      labels: { fill: theme.colour.WHITE_COLOR, fontSize: "12px" }
     },
 
     // Azure WIDGET BAR STYLES
     AzureBar: {
-      data: { fill: PURPLE_COLOR },
-      labels: { fill: WHITE_COLOR, fontSize: "12px" }
+      data: { fill: theme.colour.PURPLE_COLOR },
+      labels: { fill: theme.colour.WHITE_COLOR, fontSize: "12px" }
     },
 
     // GOOGLE CLOUD COST WIDGET BAR STYLES
     GCPBar: {
-      data: { fill: RED_COLOR },
-      labels: { fill: WHITE_COLOR, fontSize: "12px" }
+      data: { fill: theme.colour.RED_COLOR },
+      labels: { fill: theme.colour.WHITE_COLOR, fontSize: "12px" }
     },
 
     // TOTAL MEMORY WIDGET BAR STYLES
     MemoryLine: {
-      data: { stroke: YELLOW_COLOR, strokeWidth: 6 },
+      data: { stroke: theme.colour.YELLOW_COLOR, strokeWidth: 6 },
       parent: { border: "1px solid #ccc" },
-      labels: { fill: WHITE_COLOR, fontSize: "12px" }
+      labels: { fill: theme.colour.WHITE_COLOR, fontSize: "12px" }
     }
   };
 }
 
 export const WidgetTitle = styled.h3`
-  padding-top: 1.5rem;
+  padding-top: ${theme.spacing.lg};
   margin-top: 0;
   margin-bottom: 0;
-  font-size: 1.5rem;
+  font-size: ${theme.font.xl};
   background: #292a29;
   color: #ffffff;
 
-  ${mqW[1]} {
-    font-size: 1rem;
+  ${mqW[2]} {
+    font-size: ${theme.font.lg};
   }
-`;
+
+  ${mqW[0]} {
+    font-size: ${theme.font.sm};
+    padding-top: 0.4rem;
+  }
+
+  @media (max-height: 575px) and (max-width: 1200px) {
+    padding-top: ${theme.spacing.md};
+    font-size: ${theme.font.lg};
+  }
+
+  @media (max-height: 575px) and (max-width: 700px) {
+    padding-top: 0.4rem;
+    font-size: ${theme.font.sm};
+  }
+`; //These last two queries I had to make custom due to weird issues happening at these specific dimensions
 
 export const Panel = styled.div`
   text-align: center;
   border: 2px solid #171717;
-  color: white;
+  color: ${theme.colour.WHITE_COLOR};
 `;
 
 export const chartContainer = css`
-  padding-left: 1rem;
+  padding-left: ${theme.spacing.two};
   width: 90%;
   height: 100%;
+
+  ${mqW[2]} {
+    padding-left: ${theme.spacing.md};
+  }
+`;
+
+export const chartContainerSM = css`
+  padding-left: 1.5rem;
+  ${chartContainer}
 `;
 
 export const StyledCell = styled(Cell)`
   height: 80%;
 
-  ${mqH[1]} {
+  ${mqH[2]} {
     height: 70%;
   }
 

--- a/src/styles.tsx
+++ b/src/styles.tsx
@@ -25,13 +25,13 @@ export const theme = {
     PURPLE_COLOR: "#b19cd9"
   },
   font: {
-    xs: "8pt",
-    sm: "10pt",
-    base: "12pt",
-    md: "12pt",
-    lg: "14pt",
-    xl: "20pt",
-    xxl: "24pt"
+    xs: "0.7em", //8pt
+    sm: "0.8em", //10pt
+    base: "0.75em", //12pt
+    md: "0.75em", //12pt
+    lg: "1.2em", //14pt
+    xl: "1.6em", //20pt
+    xxl: "2em" //24pt
   },
   spacing: {
     two: "2rem",

--- a/src/widgets/AzureCost.tsx
+++ b/src/widgets/AzureCost.tsx
@@ -85,11 +85,11 @@ export default class AzureCost extends React.Component<Props, State> {
 
     return (
       <Panel data-testid="azure-cost-widget">
-        <WidgetTitle>Azure cost per month</WidgetTitle>
+        <WidgetTitle>Azure cost per month (in $)</WidgetTitle>
         <StyledCell center area={area}>
           <div css={chartContainer}>
             <VictoryChart
-              domainPadding={30}
+              domainPadding={50}
               style={{
                 parent: { background: "#292A29", height: "100%" }
               }}

--- a/src/widgets/Empty.tsx
+++ b/src/widgets/Empty.tsx
@@ -1,7 +1,13 @@
 import React from "react";
 import { Area } from "../types";
 import { VictoryChart, VictoryTheme, VictoryAxis } from "victory";
-import { getStyles, Panel, WidgetTitle, StyledCell } from "../styles";
+import {
+  getStyles,
+  Panel,
+  WidgetTitle,
+  StyledCell,
+  chartContainer
+} from "../styles";
 
 interface Props {
   area: Area;
@@ -18,6 +24,7 @@ export default class Empty extends React.Component<Props> {
         <WidgetTitle>Placeholder widget</WidgetTitle>
         <StyledCell area={area} center>
           <VictoryChart
+            domainPadding={50}
             style={{
               parent: {}
             }}

--- a/src/widgets/GoogleCloudCost.tsx
+++ b/src/widgets/GoogleCloudCost.tsx
@@ -93,7 +93,7 @@ export default class GoogleCloudCost extends React.Component<Props, State> {
     return (
       <Panel data-testid="gcp-cost-widget">
         <WidgetTitle>GCP cost per month</WidgetTitle>
-        <StyledCell area={area}>
+        <StyledCell center area={area}>
           <div css={chartContainer}>
             <VictoryChart
               domainPadding={50}

--- a/src/widgets/PageHeader.tsx
+++ b/src/widgets/PageHeader.tsx
@@ -59,7 +59,7 @@ const PageHeader = () => {
     <div css={header}>
       <div>
         <div css={titleContainer}>
-          <h1>Dashboard UI</h1>
+          <h1>CDS Dashboard</h1>
           <PhaseBadge />
         </div>
         <nav css={navStyle}>

--- a/src/widgets/PageHeader.tsx
+++ b/src/widgets/PageHeader.tsx
@@ -3,60 +3,76 @@ import { jsx, css } from "@emotion/core";
 import React from "react";
 import { Link } from "@reach/router";
 import CdsLogo from "../CdsLogo";
-import PhaseBadge from "./PhaseBadge"
+import PhaseBadge from "./PhaseBadge";
+import { mqW } from "../styles";
 
 const navStyle = css`
-color: white;
-
-a {
   color: white;
-}
+
+  a {
+    color: white;
+  }
 `;
 
 const header = css`
-background: #171717;
-padding: 2rem;
+  background: #171717;
+  padding: 2rem;
 
-display: flex;
-justify-content: space-between;
-align-items: center;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
 
-svg {
-  width: 4rem;
-}
+  svg {
+    width: 4rem;
+  }
 
-h1 {
-  color: white;
-  margin: 0;
-  line-height: 1.2rem;
-}
+  h1 {
+    color: white;
+    margin: 0;
+    line-height: 1.6rem;
+    font-size: 24pt;
+  }
+
+  ${mqW[0]} {
+    h1 {
+      font-size: 16pt;
+    }
+
+    a {
+      font-size: 10pt;
+    }
+
+    svg {
+      display: none;
+    }
+  }
 `;
 
 const titleContainer = css`
   display: flex;
   margin-bottom: 1rem;
   align-items: center;
-`
+`;
 
 const PageHeader = () => {
   return (
     <div css={header}>
-        <div>
-            <div css={titleContainer}>
-                <h1>CDS Dashboard</h1>
-                <PhaseBadge />
-            </div>
-            <nav css={navStyle}>
-                <Link to="/">Home</Link>
-                &nbsp; | &nbsp;
-                <Link to="/cost">Cost Dashboard</Link>
-                &nbsp; | &nbsp;
-                <Link to="/vac">VAC Dashboard</Link>
-            </nav>
+      <div>
+        <div css={titleContainer}>
+          <h1>Dashboard UI</h1>
+          <PhaseBadge />
         </div>
-        <div>
-          <CdsLogo />
-        </div>
+        <nav css={navStyle}>
+          <Link to="/">Home</Link>
+          &nbsp; | &nbsp;
+          <Link to="/cost">Cost Dashboard</Link>
+          &nbsp; | &nbsp;
+          <Link to="/vac">VAC Dashboard</Link>
+        </nav>
+      </div>
+      <div>
+        <CdsLogo />
+      </div>
     </div>
   );
 };

--- a/src/widgets/PhaseBadge.tsx
+++ b/src/widgets/PhaseBadge.tsx
@@ -1,21 +1,25 @@
 /** @jsx jsx */
 import { jsx, css } from "@emotion/core";
+import { mqW } from "../styles";
 import React from "react";
 
 const phaseBadge = css`
   background: #f90277;
-  font-size: 1.2rem;
+  font-size: 14pt;
   border-radius: 0.5rem;
   color: white;
   font-weight: 700;
   padding: 0.2rem 0.8rem;
   margin-left: 1rem;
-`
+
+  ${mqW[0]} {
+    font-size: 10pt;
+    margin-left: 0.8rem;
+  }
+`;
 
 const PhaseBadge = () => {
-    return (
-      <span css={phaseBadge}>Alpha</span>
-    );
-  };
+  return <span css={phaseBadge}>Alpha</span>;
+};
 
 export default PhaseBadge;

--- a/src/widgets/ServerMemory.tsx
+++ b/src/widgets/ServerMemory.tsx
@@ -14,7 +14,7 @@ import {
   getStyles,
   Panel,
   WidgetTitle,
-  chartContainer,
+  chartContainerSM,
   StyledCell
 } from "../styles";
 
@@ -93,20 +93,19 @@ export default class ServerMemory extends React.Component<Props, State> {
 
     return (
       <Panel data-testid="server-memory-widget">
-        <WidgetTitle>Total memory usage</WidgetTitle>
+        <WidgetTitle>Total memory usage (in MB)</WidgetTitle>
         <StyledCell area={area}>
-          <div css={chartContainer}>
+          <div css={chartContainerSM}>
             <VictoryChart
               style={{
-                parent: { background: "#292A29", height: "100%" }
+                parent: {
+                  background: "#292A29",
+                  height: "100%"
+                }
               }}
             >
               <VictoryAxis style={styles.axisOne} />
-              <VictoryAxis
-                dependentAxis
-                tickFormat={(x: number) => `${x.toFixed(2)} MB`}
-                style={styles.axisYears}
-              />
+              <VictoryAxis dependentAxis style={styles.axisYears} />
               <VictoryLine
                 interpolation="natural"
                 style={styles.MemoryLine}


### PR DESCRIPTION
## This PR consists of the following:
- App now breaks to single column layout on small screens, breakpoint has also been updated to switch a little sooner.
- Removed decimal places on the Server Memory Widget as it was causing it to break from the grid and cut off the numbers from the svg viewport (couldn't find another solution).
  - also removed MB from the tick format and added "(in MB)" into the title of graph to save space.
- Spacing adjustments using height and width media queries, the app was breaking at some pretty specific dimensions.
- Added a theme object that contains all of our styles + updated with scaling font sizes and scaling spacing values (both from xs to xxl take a look in .styles.tsx if confused)
  - this way we can update font sizes etc all in one place instead of going through every file, was a bit of work to set up but it will make our lives easier down the line.
- Finally applied some media queries to the header as it scales down


 ** ***Tested on large 720p - 1080p screens but still looks a little wonky on 4k screens unless you zoom in to 300%, we should probably add a couple more media queries to deal with this***