### PR TITLE
Fixed the firefox bug... mostly

### DIFF
--- a/src/widgets/BarChart.js
+++ b/src/widgets/BarChart.js
@@ -18,32 +18,33 @@ const barStyle = css`
     color: white;
     fill: white;
     text-anchor: middle;
+    opacity: 0;
   }
   .text-background {
     fill: #292A29;
     opacity: 0;
   }
   rect {
+    opacity: 1;
     :hover {
       opacity: 0.8;
     }
   }
-  .bar-group {
-    :hover {
-      .text {
-        opacity: 1;
-      }
-      .text-background {
-        opacity: 1;
-      }
+`;
+
+const barGroup = css`
+  :hover {
+    .text {
+      opacity: 1;
     }
-  }
-  .text {
-    opacity: 0;
+    .text-background {
+      opacity: 1;
+    }
   }
 `;
 
 const BarChart = (props) => {
+  const isFirefox = typeof InstallTrigger !== 'undefined';
   const { x, y, height, margin, ariaLabel } = props;
   var data = props.data.map(x => {
     x.textPosition = d3.max(props.data.filter(y => y.startDate.toDateString() === x.startDate.toDateString()), d => d.v1);
@@ -69,7 +70,7 @@ const BarChart = (props) => {
       {data.map((d, i) => (
         <g
         key={i}
-        className="bar-group"
+        css={isFirefox ? null : barGroup}
         transform={"translate(" + x(d.startDate) + ", 0)"}
         aria-label={ariaLabel(d)}
         >

--- a/src/widgets/Deploys.js
+++ b/src/widgets/Deploys.js
@@ -123,8 +123,6 @@ export default class Deploys extends React.Component {
     if (svg){
       width = svg.clientWidth || svg.parentNode.clientWidth;
     }
-    console.log("width: " + width)
-    console.log("height: " + height)
 
     let data = this.getData();
     let x = d3.scaleTime()

--- a/src/widgets/Deploys.js
+++ b/src/widgets/Deploys.js
@@ -7,7 +7,7 @@ import * as d3 from "d3";
 import BarChart from "./BarChart";
 
 let width = 0;
-let height = 0;
+let height = 300;
 
 let margin = {
   top: 20,
@@ -104,9 +104,9 @@ export default class Deploys extends React.Component {
   };
 
   componentDidUpdate(prevProps) {
-    const newWidth = document.getElementById(this.chartId).clientWidth;
-    const newHeight = document.getElementById(this.chartId).clientHeight;
-      if(Math.abs(newWidth - width) > 5 || Math.abs(newHeight - height) > 5) {
+    var svg = document.getElementById(this.chartId);
+    const newWidth = svg.clientWidth || svg.parentNode.clientWidth;
+      if(Math.abs(newWidth - width) > 5) {
         this.setState({counter: this.state.counter + 1});
       }
   }
@@ -119,10 +119,12 @@ export default class Deploys extends React.Component {
       );
     }
 
-    if (document.getElementById(this.chartId)){
-      width = document.getElementById(this.chartId).clientWidth;
-      height = document.getElementById(this.chartId).clientHeight;
+    var svg = document.getElementById(this.chartId);
+    if (svg){
+      width = svg.clientWidth || svg.parentNode.clientWidth;
     }
+    console.log("width: " + width)
+    console.log("height: " + height)
 
     let data = this.getData();
     let x = d3.scaleTime()
@@ -162,7 +164,7 @@ export default class Deploys extends React.Component {
           <svg
             id={this.chartId}
             width="100%"
-            height="300"
+            height={height}
             aria-label="Bar chart showing monthly deploys"
             >
             <BarChart

--- a/src/widgets/ResearchActivity.js
+++ b/src/widgets/ResearchActivity.js
@@ -7,7 +7,7 @@ import * as d3 from "d3";
 import BarChart from "./BarChart";
 
 let width = 0;
-let height = 0;
+let height = 200;
 let margin = {
   top: 20,
   right: 30,
@@ -77,9 +77,9 @@ export default class ResearchActivity extends React.Component {
   };
 
   componentDidUpdate() {
-    const newWidth = document.getElementById(chartId).clientWidth;
-    const newHeight = document.getElementById(chartId).clientHeight;
-      if(Math.abs(newWidth - width) > 5 || Math.abs(newHeight - height) > 5) {
+    let svg = document.getElementById(chartId);
+    const newWidth = svg.clientWidth || svg.parentNode.clientWidth;
+      if(Math.abs(newWidth - width) > 5) {
         this.setState({counter: this.state.counter + 1});
       }
   }
@@ -91,10 +91,9 @@ export default class ResearchActivity extends React.Component {
         <Loader t={t}/>
       );
     }
-
-    if (document.getElementById(chartId)){
-      width = document.getElementById(chartId).clientWidth;
-      height = document.getElementById(chartId).clientHeight;
+    let svg = document.getElementById(chartId);
+    if (svg){
+      width = svg.clientWidth || svg.parentNode.clientWidth;
     }
 
     let data = this.getData();
@@ -127,7 +126,7 @@ export default class ResearchActivity extends React.Component {
           <svg
             id={chartId}
             width="100%"
-            height="200"
+            height={height}
             aria-label="Bar chart showing number of research participants each month"
             >
             <BarChart


### PR DESCRIPTION
The charts are now rendering - firefox returns 0 for the clientWidth/height of svg for pedantic reasons. There is another issue with using css hover selectors to set opacity of an svg element. It's not working and I couldn't figure it out so I'm just disabling the hover text in firefox for now.